### PR TITLE
Add optional basic_auth for digitransit

### DIFF
--- a/roles/digitransit_caddy/templates/digitransit.caddy
+++ b/roles/digitransit_caddy/templates/digitransit.caddy
@@ -1,3 +1,9 @@
 {{ digitransit_domain_name }} {
   reverse_proxy /* localhost:{{ digitransit_port }}
+
+{% if digitransit_ui_user is defined %}
+  basicauth / {
+    {{ digitransit_ui_user }} {{ digitransit_ui_password | password_hash('bcrypt', salt='ZZjxxx7R7p7z65GHj4ih8J' ) }}
+  }
+{% endif %}
 }


### PR DESCRIPTION
This PR adds an optional basic_auth authentication for digitransit.

To activate it, the variables

`digitransit_ui_user` needs to be defined, the password is supplied via `digitransit_ui_password`.