### PR TITLE
Add OTP_TIMEOUT configuration option

### DIFF
--- a/roles/digitransit/defaults/main.yml
+++ b/roles/digitransit/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 digitransit_port: 8081
 digitransit_image: "docker.io/lehrenfried/digitransit-ui:latest"
+digitransit_otp_timeout: 12000

--- a/roles/digitransit/templates/systemd/digitransit.service
+++ b/roles/digitransit/templates/systemd/digitransit.service
@@ -21,6 +21,7 @@ ExecStart=podman run -i --rm --name %N \
  -e GEOCODING_BASE_URL={{ digitransit_geocoder_baseurl }} \
  -e OTP_URL="https://{{ digitransit_otp_domain }}/otp/routers/default/" \
  -e API_URL="https://{{ digitransit_otp_domain }}" \
+ -e OTP_TIMEOUT={{ digitransit_otp_timeout }} \
  {{ digitransit_image }}
 
 ExecStop=podman stop --ignore %N


### PR DESCRIPTION
This PR adds an option to customize digitransit's OTP_TIMEOUT, which defaults to 12s.