### PR TITLE
Add MATOMO_URL and MATOMO_SITE_ID env vars

### DIFF
--- a/roles/digitransit/templates/systemd/digitransit.service
+++ b/roles/digitransit/templates/systemd/digitransit.service
@@ -19,7 +19,9 @@ ExecStart=podman run -i --rm --name %N \
  -e CONFIG={{ digitransit_config }} \
  -e ROOTLINK=https://{{ digitransit_otp_domain }} \
  -e GEOCODING_BASE_URL={{ digitransit_geocoder_baseurl }} \
- -e OTP_URL="https://{{ digitransit_otp_domain }}/otp/routers/default/" \
+ {% if digitransit_matomo_url is defined %} -e MATOMO_URL={{ digitransit_matomo_url }} \
+ {% endif %}{% if digitransit_matomo_site_id is defined %} -e MATOMO_SITE_ID={{ digitransit_matomo_site_id }} \
+ {% endif %} -e OTP_URL="https://{{ digitransit_otp_domain }}/otp/routers/default/" \
  -e API_URL="https://{{ digitransit_otp_domain }}" \
  {{ digitransit_image }}
 


### PR DESCRIPTION
This PR adds optional env vars `MATOMO_URL` and `MATOMO_SITE_ID`, which can be set via `digitransit_matomo_url` and `digitransit_matomo_site_id`.