### PR TITLE
Extract gtfsrthttp2mqtt image as variable

### DIFF
--- a/roles/vehicle_positions/defaults/main.yml
+++ b/roles/vehicle_positions/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 vehicle_positions_poll_interval: 5
+gtfsrthttp2mqtt_image: "docker.io/hsldevcom/gtfsrthttp2mqtt:prod-2022-04-11T14.29.37-de608e5"

--- a/roles/vehicle_positions/templates/gtfsrt2mqtt.service
+++ b/roles/vehicle_positions/templates/gtfsrt2mqtt.service
@@ -16,7 +16,7 @@ ExecStart=podman run --name %n --rm \
     -e FEED_NAME={{ mqtt_feed_id }}\
     -e INTERVAL={{ vehicle_positions_poll_interval }} \
     -e OTP_URL=https://{{ mqtt_otp_domain }}/otp/gtfs/v1 \
-    docker.io/hsldevcom/gtfsrthttp2mqtt:prod-2022-04-11T14.29.37-de608e5
+    {{ gtfsrthttp2mqtt_image }}
 
 ExecStop=-podman stop --ignore %n
 ExecStop=-podman rm %n


### PR DESCRIPTION
This PR introduces a new variable `gtfsrthttp2mqtt_image` to make the image configurable. 

Note: For now, the (rather old) image version is unchanged to avoid unintended changes.