### PR TITLE
restart tileserver after tilemaker terminates

### DIFF
--- a/roles/tilemaker/templates/tilemaker.service
+++ b/roles/tilemaker/templates/tilemaker.service
@@ -8,6 +8,7 @@ StartLimitBurst=3
 [Service]
 WorkingDirectory={{ tilemaker_work_dir }}
 ExecStart={{ tilemaker_work_dir }}/build-mbtiles
+ExecStartPost=systemctl restart tileserver
 RestartSec=10m
 Restart=on-failure
 


### PR DESCRIPTION
Unsure how this affects production since we have different machines. Most likely, nothing will happen, but also nothing will break.