### PR TITLE
Remove '--update' option from rsync command

### DIFF
--- a/roles/tileserver/templates/systemd/tileserver.service
+++ b/roles/tileserver/templates/systemd/tileserver.service
@@ -21,7 +21,6 @@ MemoryMax=90%
 # rsync makes sure that it's a noop when the files are the same
 ExecStartPre=-/bin/sh -c 'rsync \
   --progress \
-  --update \
   --stats \
   {{ tileserver_mbtiles_path }} \
   {{ tileserver_work_dir }}/input.mbtiles || send-to-matrix "⚠️ rsync failed on {{ matrix_hostname }}"'


### PR DESCRIPTION
rsynch should always download the file from now on. Previously, for example, the download would not start if there was a corrupted file at the destination.