### PR TITLE
Make availability of raster tiles configurable for each style

### DIFF
--- a/roles/tileserver/defaults/main.yml
+++ b/roles/tileserver/defaults/main.yml
@@ -25,3 +25,7 @@ tileserver_restart_time: "06:00:00"
 tileserver_restart_on_change: true
 
 tileserver_mbtiles_path: "{{ tilemaker_work_dir }}/tilemaker-output.mbtiles"
+
+streets_serve_rendered: true
+bicycle_serve_rendered: true
+satellite_overlay_serve_rendered: true

--- a/roles/tileserver/tasks/main.yml
+++ b/roles/tileserver/tasks/main.yml
@@ -38,36 +38,36 @@
 
 - name: Install extra layers
   ansible.builtin.copy:
-    src: "tileserver/{{ item }}/style.json"
-    dest: "{{ tileserver_work_dir }}/{{ item }}.json"
+    src: "tileserver/{{ item.name }}/style.json"
+    dest: "{{ tileserver_work_dir }}/{{ item.name }}.json"
   with_items: "{{ tileserver_extra_styles }}"
   notify: "{{ tileserver_restart_on_change | ternary('Restart tileserver', []) }}"
 
 - name: Copy extra_layer sprites sprite.json
   ansible.builtin.copy:
-    src: "tileserver/{{ item }}//sprite.json"
-    dest: "{{ tileserver_work_dir }}/sprites/{{ item }}.json"
+    src: "tileserver/{{ item.name }}//sprite.json"
+    dest: "{{ tileserver_work_dir }}/sprites/{{ item.name }}.json"
   with_items: "{{ tileserver_extra_styles }}"
   notify: "{{ tileserver_restart_on_change | ternary('Restart tileserver', []) }}"
 
 - name: Copy extra_layer sprites sprite@2x.json
   ansible.builtin.copy:
-    src: "tileserver/{{ item }}//sprite@2x.json"
-    dest: "{{ tileserver_work_dir }}/sprites/{{ item }}@2x.json"
+    src: "tileserver/{{ item.name }}//sprite@2x.json"
+    dest: "{{ tileserver_work_dir }}/sprites/{{ item.name }}@2x.json"
   with_items: "{{ tileserver_extra_styles }}"
   notify: "{{ tileserver_restart_on_change | ternary('Restart tileserver', []) }}"
 
 - name: Copy extra_layer sprites sprite.png
   ansible.builtin.copy:
-    src: "tileserver/{{ item }}//sprite.png"
-    dest: "{{ tileserver_work_dir }}/sprites/{{ item }}.png"
+    src: "tileserver/{{ item.name }}//sprite.png"
+    dest: "{{ tileserver_work_dir }}/sprites/{{ item.name }}.png"
   with_items: "{{ tileserver_extra_styles }}"
   notify: "{{ tileserver_restart_on_change | ternary('Restart tileserver', []) }}"
 
 - name: Copy extra_layer sprites sprite@2x.png
   ansible.builtin.copy:
-    src: "tileserver/{{ item }}//sprite@2x.png"
-    dest: "{{ tileserver_work_dir }}/sprites/{{ item }}@2x.png"
+    src: "tileserver/{{ item.name }}//sprite@2x.png"
+    dest: "{{ tileserver_work_dir }}/sprites/{{ item.name }}@2x.png"
   with_items: "{{ tileserver_extra_styles }}"
   notify: "{{ tileserver_restart_on_change | ternary('Restart tileserver', []) }}"
 

--- a/roles/tileserver/templates/tileserver-config.json
+++ b/roles/tileserver/templates/tileserver-config.json
@@ -26,6 +26,10 @@
           49.794564
         ]
       }
+      {% if streets_serve_rendered is false %}
+      ,
+      "serve_rendered": false
+      {% endif %}
     },
     "satellite-overlay": {
       "style": "satellite-overlay.json",
@@ -38,6 +42,10 @@
           49.794564
         ]
       }
+      {% if satellite_overlay_serve_rendered is false %}
+      ,
+      "serve_rendered": false
+      {% endif %}
     },
     "bicycle": {
       "style": "bicycle.json",
@@ -50,12 +58,17 @@
           49.794564
         ]
       }
+      {% if bicycle_serve_rendered is false %}
+      ,
+      "serve_rendered": false
+      {% endif %}
     }
-{% for style_name in tileserver_extra_styles %}
+{% for extra_style in tileserver_extra_styles %}
     ,
-    "{{ style_name }}": {
-      "style": "{{ style_name }}.json",
-      "serve_data": true
+    "{{ extra_style.name }}": {
+      "style": "{{ extra_style.name }}.json",
+      "serve_data": true,
+      "serve_rendered": {{ extra_style.serve_rendered | tojson }}
     }
 {% endfor %}
   },


### PR DESCRIPTION
In [tileserver-ansible](https://github.com/mobidata-bw/tileserver-ansible/blob/main/group_vars/all.yml) the configuration will be as follows to correspond to the proposed changes of ansible-baseline:

```
tileserver_extra_styles:
  - name: streets
    serve_rendered: false
  - name: streets-v2
    serve_rendered: false
  - name: railway
    serve_rendered: false
  - name: railway-v2
    serve_rendered: true
  - name: aerialphotos
    serve_rendered: true
  - name: darkmatter
    serve_rendered: false

streets_serve_rendered: false
bicycle_serve_rendered: false
satellite_overlay_serve_rendered: false
```